### PR TITLE
fix gunters-chain definition

### DIFF
--- a/src/minderbinder/length.clj
+++ b/src/minderbinder/length.clj
@@ -51,7 +51,8 @@
   :chain :surveyors-chain
   :chain #{:survey-chain :ch}
   :link :surveyors-link
-  :gunters-chain #{:surveyors-chain :chain}
+  :gunters-chain :chain
+  :gunters-chain :surveyors-chain
   :engineers-chain [100 :ft]
   :engineers-link [1/100 :engineers-chain]
   :ramsden-chain :engineers-chain


### PR DESCRIPTION
```clojure
user=> (require '[minderbinder.length])

CompilerException java.lang.Exception: Undefined unit :gunters-chain, compiling:(minderbinder/length.clj:6:1)
```